### PR TITLE
Add i128/u128 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ std = [ "thiserror" ]
 default = [ "std" ]
 
 [dependencies]
-num-traits = { version = "0.2.15", default_features = false }
+num-traits = { version = "0.2.15", default_features = false, features = ["i128"] }
 thiserror = { version = "1.0.38", optional = true, default_features = false }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ std = [ "thiserror" ]
 default = [ "std" ]
 
 [dependencies]
-num-traits = { version = "0.2.15", default_features = false, features = ["i128"] }
-thiserror = { version = "1.0.38", optional = true, default_features = false }
+num-traits = { version = "0.2.15", default-features = false, features = ["i128"] }
+thiserror = { version = "1.0.38", optional = true, default-features = false }
 
 [dev-dependencies]
 rand = { version = "0.8.5" }

--- a/src/helpers/fractional.rs
+++ b/src/helpers/fractional.rs
@@ -179,8 +179,6 @@ mod test {
 
     fn encode_frac<N: Number>(tests: &[(N, N, &'static str)]) {
         for (v, d, s) in tests {
-            println!("test v: {} d: {} s: {}", v, d, s);
-
             let d = Fractional::<N>::new(*v, *d);
 
             assert_eq!(d.len(), s.len(), "invalid length for value: {}", s);

--- a/src/helpers/hex.rs
+++ b/src/helpers/hex.rs
@@ -47,6 +47,9 @@ impl <B: AsRef<[u8]>> EncodeStr for Hex<B> {
 
 #[cfg(test)]
 mod test {
+    extern crate alloc;
+    extern crate std;
+    use alloc::string::ToString;
     use super::{Hex, EncodeStr, HEX_MAP};
 
     #[test]
@@ -64,7 +67,7 @@ mod test {
         for i in 0..HEX_MAP.len() {
 
             let a = HEX_MAP[i].to_string();
-            let e = format!("{:x}", i);
+            let e = std::format!("{:x}", i);
 
             assert_eq!(&a, &e);
         }

--- a/src/types/int.rs
+++ b/src/types/int.rs
@@ -110,12 +110,14 @@ impl_uint_encode!(u8);
 impl_uint_encode!(u16);
 impl_uint_encode!(u32);
 impl_uint_encode!(u64);
+impl_uint_encode!(u128);
 impl_uint_encode!(usize);
 
 impl_sint_encode!(i8);
 impl_sint_encode!(i16);
 impl_sint_encode!(i32);
 impl_sint_encode!(i64);
+impl_sint_encode!(i128);
 impl_uint_encode!(isize);
 
 #[cfg(test)]
@@ -224,4 +226,53 @@ mod test {
             assert_eq!(e, *s, "encode failed for value: {}", v);
         }
     }
+
+    #[test]
+    fn encode_u128() {
+        let tests: &[(u128, &str)] = &[
+            (0, "0"),
+            (1, "1"),
+            (1243566, "1243566"),
+            (u64::MAX as u128, "18446744073709551615"),
+            (u128::MAX, "340282366920938463463374607431768211455"),
+        ];
+
+        for (v, s) in tests {
+            let mut buff = [0u8; 39];
+
+            assert_eq!(v.len(), s.len(), "length mismatch for value: {}", v);
+
+            let e = v.write_str(&mut buff).unwrap();
+
+            assert_eq!(e, *s, "encode failed for value: {}", v);
+        }
+    }
+
+
+    #[test]
+    fn encode_i128() {
+        let tests: &[(i128, &str)] = &[
+            (0, "0"),
+            (1, "1"),
+            (-1, "-1"),
+            (1243566, "1243566"),
+            (-1243566, "-1243566"),
+            (i64::MAX as i128, "9223372036854775807"),
+            ((i64::MIN + 1) as i128, "-9223372036854775807"),
+            (i64::MIN as i128, "-9223372036854775808"),
+            ((i128::MIN + 1) as i128, "-170141183460469231731687303715884105727"),
+            // TODO: handle actual i128::MIN
+        ];
+
+        for (v, s) in tests {
+            let mut buff = [0u8; 40];
+
+            assert_eq!(v.len(), s.len(), "length mismatch for value: {}", v);
+
+            let e = v.write_str(&mut buff).unwrap();
+
+            assert_eq!(e, *s, "encode failed for value: {}", v);
+        }
+    }
+
 }


### PR DESCRIPTION
I'm working on upreving the `mobilecoin` submodule in the Ledger app, and in the current revision the tx summary report now contains i128/u128 values, so ideally this crate can be adapted to support that.

Thanks!